### PR TITLE
Distribution Handling, Agent Profile, and Starting ossec-remoted

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,15 +2,6 @@
 # handlers file for ossec-agent
 
 - name: restart ossec-agent
-  service: name=ossec
+  service: name={{ ossec_init_name }}
            state=restarted
            enabled=yes
-  when: (ansible_os_family != "RedHat" or ansible_os_family != "CentOS")
-
-- name: restart ossec-agent
-  service: name=ossec-hids
-           state=restarted
-           enabled=yes
-  when: (ansible_os_family == "RedHat" or ansible_os_family == "CentOS") and
-        (ansible_distribution_major_version == "7")
-

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,22 +1,12 @@
 ---
-#
-
-#- name: Debian | Set some facts
-
-- name: Debian | Installing repository Debian
-  shell: "echo \"deb http://ossec.alienvault.com/repos/apt/debian {{ ansible_distribution_release }} main\" >> /etc/apt/sources.list"
-#  apt_repository: repo="deb http://ossec.alienvault.com/repos/apt/debian {{ ansible_distribution_release }} main"
-#                  state=present
-
-- name: Debian | Installing repository key
+- name: Debian/Ubuntu | Installing repository key
   apt_key: url=http://ossec.alienvault.com/repos/apt/conf/ossec-key.gpg.key
-           id=9A1B1C65
 
-- name: Debian | Install ossec-hids-agent
+- name: Debian/Ubuntu | Installing repository
+  apt_repository: repo="deb http://ossec.alienvault.com/repos/apt/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main" state=present
+
+- name: Debian/Ubuntu | Install ossec-hids-agent
   apt: pkg=ossec-hids-agent
        state=present
        update_cache=yes
        cache_valid_time=3600
-  
-
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,9 +9,21 @@
   include: "Debian.yml"
   when: ansible_os_family == "Debian"
 
+- name: Set ossec deploy facts for RedHat
+  set_fact:
+    ossec_agent_config_filename: ossec-agent.conf
+    ossec_init_name: ossec-hids
+  when: ansible_os_family == "RedHat"
+
+- name: Set ossec deploy facts for Debian
+  set_fact:
+    ossec_agent_config_filename: ossec.conf
+    ossec_init_name: ossec
+  when: ansible_os_family == "Debian"
+
 - name: "Installing the ossec-agent.conf"
   template: src=var-ossec-etc-ossec-agent.conf.j2
-            dest=/var/ossec/etc/ossec-agent.conf
+            dest=/var/ossec/etc/{{ ossec_agent_config_filename }}
             owner=root
             group=root
             mode=0644
@@ -60,3 +72,6 @@
   pause: minutes=1
   when: check_keys.stat.exists == false and ossec_server_name|default("") == ""
 
+- name: "Start ossec-remoted on server. If this is the first agent added it will not be running."
+  shell: /var/ossec/bin/ossec-control start
+  delegate_to: "{{ ossec_server_name }}"

--- a/templates/var-ossec-etc-ossec-agent.conf.j2
+++ b/templates/var-ossec-etc-ossec-agent.conf.j2
@@ -3,5 +3,8 @@
 <ossec_config>
   <client>
     <server-ip>{{ ossec_server_ip }}</server-ip>
+    {% if ossec_profile is defined %}
+    <config-profile>{{ ossec_profile }}</config-profile>
+    {% endif %}
   </client>
 </ossec_config>


### PR DESCRIPTION
This pull requests:
- makes updates RedHat/Debian distribution handling
- adds an agent profile settingt
- fixes the start of remoted on the server when the first agent is added
