### PR TITLE
include no dependencies

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -39,7 +39,7 @@ galaxy_info:
     - all
   categories:
   - monitoring
-#dependencies: []
+dependencies: []
   # List your role dependencies here, one per line. Only
   # dependencies available via galaxy should be listed here.
   # Be sure to remove the '[]' above if you add dependencies


### PR DESCRIPTION
Added empty dependency list so that ansible-galaxy can checkout from a git repository.
