### PR TITLE
Allow for situations where the ossec server is not managed by ansible

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Role Variables
 This role needs 2 parameters:
 * `ossec_server_ip`: This is the ip address of the server running the ossec-server.
 * `ossec_server_name`: This is the hostname of the server running the ossec-server. 
+* `ossec_managed_server`: When set to false, tasks that delegate to ossec server will be skipped
 
 This role has 2 tasks with 'delagation_to' which needs the parameter `ossec_server_name`. When this parameter is not set, you'll need to run manually the `/var/ossec/bin/ossec-authd` on the server and `/var/ossec/bin/agent-auth` on the agent. When this is the case, it will show you an message with the exact command line.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,4 @@
 
 ossec_server_ip: 127.0.0.1
 ossec_server_name: ""
+ossec_managed_server: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,7 +42,7 @@
 # on the server. So we set ignore_errors to true
 - name: "Starting auth daemon on server {{ ossec_server_name }}"
   shell: '/var/ossec/bin/ossec-authd -p 1515 >/dev/null 2>&1 &'
-  when: check_keys.stat.exists == false and ossec_server_name|default("") != ""
+  when: ossec_managed_server and check_keys.stat.exists == false and ossec_server_name|default("") != ""
   delegate_to: "{{ ossec_server_name }}"
   ignore_errors: yes
   tags:
@@ -50,7 +50,7 @@
 
 - name: 'Please execute the following command on your ossec-server: "/var/ossec/bin/ossec-authd -p 1515 >/dev/null 2>&1 &"'
   pause: minutes=2
-  when: check_keys.stat.exists == false and ossec_server_name|default("") == "" 
+  when: ossec_managed_server and check_keys.stat.exists == false and ossec_server_name|default("") == ""
 
 - name: "register client"
   shell: /var/ossec/bin/agent-auth -m {{ ossec_server_ip }} -p 1515
@@ -63,15 +63,16 @@
 - name: "kill the auth-daemon on server {{ ossec_server_name }}"
   shell: /usr/bin/pkill -f /var/ossec/bin/ossec-authd
   delegate_to: "{{ ossec_server_name }}"
-  when: check_keys.stat.exists == false and ossec_server_name|default("") != ""
+  when: ossec_managed_server and check_keys.stat.exists == false and ossec_server_name|default("") != ""
   ignore_errors: yes
   tags:
     - config
 
 - name: 'Please execute the following command on your ossec-server: "/usr/bin/pkill -f /var/ossec/bin/ossec-authd"'
   pause: minutes=1
-  when: check_keys.stat.exists == false and ossec_server_name|default("") == ""
+  when: ossec_managed_server and check_keys.stat.exists == false and ossec_server_name|default("") == ""
 
 - name: "Start ossec-remoted on server. If this is the first agent added it will not be running."
   shell: /var/ossec/bin/ossec-control start
   delegate_to: "{{ ossec_server_name }}"
+  when: ossec_managed_server


### PR DESCRIPTION
In our environment, we do not have control of or access to the ossec server. This allows us to disable the tasks that would delegate to the ossec server.
