### PR TITLE
Set permisisons on client.keys file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,6 +70,11 @@
     - config
     - skip_ansible_lint
 
+- name: Set permissions on client.keys file
+  file:
+    dest: /var/ossec/etc/client.keys
+    mode: 0640
+
 - name: "kill the auth-daemon on server {{ ossec_server_name }}"
   service: name=ossec-authd state=stopped
   delegate_to: "{{ ossec_server_name }}"


### PR DESCRIPTION
Sets mode/permissions on `client.keys` file to 0640 to ensure file is not world-readable.