### PR TITLE
Optionally disable public repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,18 @@ So, you'll need one of those operating systems.. :-)
 Role Variables
 --------------
 
-This role needs 5 parameters:
+This role needs 4 parameters:
 * `ossec_server_ip`: This is the ip address of the server running the ossec-server.
 * `ossec_server_fqdn`: This is the fqdn of the server running the ossec-server.
 * `ossec_server_name`: This is the hostname of the server running the ossec-server used for delegate with ansible. 
 * `ossec_managed_server`: When set to false, tasks that delegate to ossec server will be skipped
-* `ossec_agent_package_name`: Default is "ossec-hids-agent".
 
 This role has 3 tasks with 'delagation_to' which needs the parameter `ossec_server_name`. When this parameter is not set, you'll need to run manually the `/var/ossec/bin/ossec-authd` on the server and `/var/ossec/bin/agent-auth` on the agent. When this is the case, it will show you an message with the exact command line.
 
 The following role variables are optional:
 * `ossec_active_response_disabled`: Disables active response if set to yes. If this is not defined active response is enabled.
 * `ossec_disable_public_repos`: Disables installation of public repositories if set to "yes".
+* `ossec_agent_package_name`: Default is "ossec-hids-agent". For RPM based systems (e.g. CentOS and RedHat), this can be a URL or path to a rpm file.
 
 Dependencies
 ------------

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This role has 3 tasks with 'delagation_to' which needs the parameter `ossec_serv
 The following role variables are optional:
 * `ossec_active_response_disabled`: Disables active response if set to yes. If this is not defined active response is enabled.
 * `ossec_disable_public_repos`: Disables installation of public repositories if set to "yes".
-* `ossec_agent_package_name`: Default is "ossec-hids-agent". For RPM based systems (e.g. CentOS and RedHat), this can be a URL or path to a rpm file.
+* `ossec_agent_package_name`: Default is "ossec-hids-agent". This can be set to a URL or path to a .rpm file or path to a .deb file if the public repositories cannot be used.
 
 Dependencies
 ------------

--- a/README.md
+++ b/README.md
@@ -21,16 +21,18 @@ So, you'll need one of those operating systems.. :-)
 Role Variables
 --------------
 
-This role needs 4 parameters:
+This role needs 5 parameters:
 * `ossec_server_ip`: This is the ip address of the server running the ossec-server.
 * `ossec_server_fqdn`: This is the fqdn of the server running the ossec-server.
 * `ossec_server_name`: This is the hostname of the server running the ossec-server used for delegate with ansible. 
 * `ossec_managed_server`: When set to false, tasks that delegate to ossec server will be skipped
+* `ossec_agent_package_name`: Default is "ossec-hids-agent".
 
 This role has 3 tasks with 'delagation_to' which needs the parameter `ossec_server_name`. When this parameter is not set, you'll need to run manually the `/var/ossec/bin/ossec-authd` on the server and `/var/ossec/bin/agent-auth` on the agent. When this is the case, it will show you an message with the exact command line.
 
-The following role variable is optional:
+The following role variables are optional:
 * `ossec_active_response_disabled`: Disables active response if set to yes. If this is not defined active response is enabled.
+* `ossec_disable_public_repos`: Disables installation of public repositories if set to "yes".
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,3 +4,4 @@
 ossec_server_name: ""
 ossec_managed_server: true
 ossec_server_atomic_release: 1.0-21
+ossec_agent_package_name: ossec-hids-agent

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -4,7 +4,3 @@
 
 - name: Debian/Ubuntu | Installing repository
   apt_repository: repo="deb http://ossec.wazuh.com/repos/apt/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main" state=present
-
-- name: Debian/Ubuntu | Install ossec-hids-agent
-  apt: pkg=ossec-hids-agent
-       state=present

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -15,10 +15,3 @@
   yum:
     name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
     state: present
-
-- name: "RedHat | Install ossec-hids-client"
-  yum:
-    pkg: "{{ ossec_agent_package_name }}"
-    state: present
-  tags:
-    - init

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,13 @@
 ---
 # tasks file for ossec-agent
 
-- name: "Include OS-specific variables"
-  include_vars: "{{ ansible_os_family }}.yml"
-
 - name: "Install the correct repository"
-  include: "RedHat.yml"
-  when: ansible_os_family == "RedHat"
+  include_tasks: "{{ ansible_os_family }}.yml"
+  when: (ossec_disable_public_repos is not defined) or (ossec_disable_public_repos != 'yes')
 
-- name: "Install the correct repository"
-  include: "Debian.yml"
-  when: ansible_os_family == "Debian"
+- name: "Install {{ ossec_agent_package_name }}"
+  package:
+    name: "{{ ossec_agent_package_name }}"
 
 - name: Set ossec deploy facts for RedHat
   set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,11 @@
 - name: "Install {{ ossec_agent_package_name }}"
   package:
     name: "{{ ossec_agent_package_name }}"
+  when: "'.deb' not in ossec_agent_package_name"
+
+- name: Install OSSEC Agent from .deb package
+  apt: deb="{{ ossec_agent_package_name }}"
+  when: "'.deb' in ossec_agent_package_name"
 
 - name: Set ossec deploy facts for RedHat
   set_fact:

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,3 +1,0 @@
----
-
-ossec_agent_package_name: ossec-hids-client

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,3 +1,0 @@
----
-
-ossec_agent_package_name: ossec-hids-agent


### PR DESCRIPTION
- Adds an optional variable `ossec_disable_public_repos` for use of the role when on a closed intranet or when access to public repos is restricted.  Private repositories would need to be installed and enabled before running this role or the `ossec_agent_package_name` would need to be changed to a .rpm or .deb package file.
- Also fixes an issue where the `ossec_agent_package_name` was set to the wrong value in `vars/Debian.yml`.  The error didn't show up because the `tasks/Debian.yml` did not use the variable for the package name.