### PR TITLE
Option to set agent name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 dj-wasabi.ossec-agent
 =========
 
-This role will install and configure an ossec-agent on the server. When there there is an parameter `ossec_server_name` configured, it will delagate an action for automatically authenticate the agent. 
+This role will install and configure an ossec-agent on the server. When there is a parameter, `ossec_server_name` configured, it will delagate an action to automatically authenticate the agent.
 
 Build Status:
 
@@ -24,7 +24,7 @@ Role Variables
 This role needs 4 parameters:
 * `ossec_server_ip`: This is the ip address of the server running the ossec-server.
 * `ossec_server_fqdn`: This is the fqdn of the server running the ossec-server.
-* `ossec_server_name`: This is the hostname of the server running the ossec-server used for delegate with ansible. 
+* `ossec_server_name`: This is the hostname of the server running the ossec-server used for delegate with ansible.
 * `ossec_managed_server`: When set to false, tasks that delegate to ossec server will be skipped
 
 This role has 3 tasks with 'delagation_to' which needs the parameter `ossec_server_name`. When this parameter is not set, you'll need to run manually the `/var/ossec/bin/ossec-authd` on the server and `/var/ossec/bin/agent-auth` on the agent. When this is the case, it will show you an message with the exact command line.
@@ -33,6 +33,7 @@ The following role variables are optional:
 * `ossec_active_response_disabled`: Disables active response if set to yes. If this is not defined active response is enabled.
 * `ossec_disable_public_repos`: Disables installation of public repositories if set to "yes".
 * `ossec_agent_package_name`: Default is "ossec-hids-agent". This can be set to a URL or path to a .rpm file or path to a .deb file if the public repositories cannot be used.
+* `ossec_agent_name`: Optional name for the OSSEC agent.  Default is to use hostname.
 
 Dependencies
 ------------
@@ -67,7 +68,7 @@ GPLv3
 Author Information
 ------------------
 
-Please send suggestion or pull requests to make this role better. 
+Please send suggestion or pull requests to make this role better.
 
 Github: https://github.com/dj-wasabi/ansible-ossec-agent
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -73,7 +73,7 @@
     - skip_ansible_lint
 
 - name: "register client"
-  shell: /var/ossec/bin/agent-auth -m {{ ossec_server_ip|default(ossec_server_fqdn) }} -p 1515
+  shell: "/var/ossec/bin/agent-auth -m {{ ossec_server_ip|default(ossec_server_fqdn) }} -p 1515 -A '{{ ossec_agent_name|default(ansible_hostname) }}'"
   args:
     creates: /var/ossec/etc/client.keys
   tags:


### PR DESCRIPTION
- Adds optional parameter `ossec_agent_name` to set the agent name to something other than the hostname if desired.  Defaults to ansible_hostname if not set.
- Minor grammar changes to README (I'm not sure about the comma I added, though).